### PR TITLE
Blind email addresses.

### DIFF
--- a/static/js/erot13.js
+++ b/static/js/erot13.js
@@ -1,0 +1,29 @@
+// https://github.com/tyea/erot13
+
+function erot13(s)
+{
+	return (s ? s : this).split("").map(function(_) {
+		if (!_.match(/[A-za-z]/)) return _;
+		c = Math.floor(_.charCodeAt(0) / 97);
+		k = (_.toLowerCase().charCodeAt(0) - 83) % 26 || 26;
+		return String.fromCharCode(k + ((c == 0) ? 64 : 96));
+	}).join("");
+}
+
+function erot13_onload(event)
+{
+	var elements = window.document.querySelectorAll("a[data-erot13]");
+	for (var j = 0; j < elements.length; j++) {
+		var element = elements[j];
+		var email = element.dataset.erot13;
+		var overwrite = element.dataset.erot13Overwrite !== undefined;
+		if (email !== undefined) {
+			element.href = "mailto:" + erot13(email);
+			if (overwrite) {
+				element.innerHTML = erot13(email);
+			}
+		}
+	}
+}
+
+window.addEventListener("load", erot13_onload);

--- a/templates/base.html
+++ b/templates/base.html
@@ -95,6 +95,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js" integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
     <script src="{% static "js/main.js" %}"></script>
+    <script src="{% static "js/erot13.js" %}"></script>
 
     {% block "templates" %}
     {% endblock "templates" %}

--- a/templates/wheretofindme/user_detail.html
+++ b/templates/wheretofindme/user_detail.html
@@ -27,7 +27,13 @@
     {% if identity.name %}
       <div class="card bg-light shadow-sm mb-3">
         {% if identity.looks_like_link %}
-          <a rel="me nofollow" href="{{ identity.url }}">
+          <a
+            rel="me nofollow"
+            {% if identity.should_blind %}
+            data-erot13="{{ identity.blind_url }}"
+            {% else %}
+            href="{{ identity.url }}"
+            {% endif %}>
         {% endif %}
         <div class="card-body">
           <span class="{{ identity.icon }}"></span>

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -1,3 +1,5 @@
+import codecs
+
 from collections import defaultdict
 from urllib.parse import urlparse
 
@@ -87,6 +89,12 @@ class InternetIdentity(models.Model):
             return "fas fa-envelope"
         netloc = urlparse(self.url).netloc
         return ICONS[netloc]
+
+    def should_blind(self):
+        return self.url.startswith("mailto:")
+
+    def blind_url(self):
+        return codecs.encode(self.url, "rot_13")
 
 
 class Follow(models.Model):


### PR DESCRIPTION
Email addresses are the only "blind" kind of identity. For all blinded identities, we use a mangled (trivially - using ROT-13) form in the DOM and translate it back into its normal form by script. This is largely cargo-cult, as I haven't been able to find any convincing guidance on what spam crawlers do and do not decode in the wild.

Rot13 rendering is from https://github.com/tyea/erot13 revision 481a3a112046f5e58980e2ce336b7f3c9d7d2da0, distributed under the BSD 3-clause license.

Fixes #30.