### PR TITLE
Prevent scrollbars from displaying on small cards.

### DIFF
--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -20,7 +20,7 @@
 
 .preview-card .card-body,
 .detail-card .card-body {
-  overflow: scroll;
+  overflow: auto;
   max-height: 8rem;
 }
 


### PR DESCRIPTION
This removes a rendering oddity on Safari by stopping it from reserving layout space for scrollbars that don't exist. That layout is only used if and when the scrollbars _do_ exist.

I considered `overflow: none;` here, but cropping large text based on layout constraints felt hostile.

Fixes #103.