### PR TITLE
Stop guessing at the ID.

### DIFF
--- a/src/components/AliasForm.vue
+++ b/src/components/AliasForm.vue
@@ -77,23 +77,16 @@ export default {
       );
     },
     create() {
-      const newId =
-        Math.max.apply(
-          Math,
-          this.aliases.map(a => a.id),
-        ) + 1;
-      const newAlias = {
-        id: newId,
-        name: '',
+      const placeholder = {
+        id: `placeholder-${Math.floor(Math.random() * 1e7)}`,
         disabled: true,
       };
-      this.aliases.push(newAlias);
+      this.aliases.push(placeholder);
       return (
         this.createNewAlias()
           .then(resp => {
-            const { id } = resp.data;
-            newAlias.disabled = false;
-            newAlias.id = id;
+            const insertAt = this.aliases.indexOf(placeholder);
+            this.aliases.splice(insertAt, 1, resp.data);
           })
           // TODO: display error state.
           .catch()

--- a/src/components/IdentitiesForm.vue
+++ b/src/components/IdentitiesForm.vue
@@ -85,26 +85,16 @@ export default {
       );
     },
     create() {
-      const newId =
-        Math.max.apply(
-          Math,
-          this.identities.map(i => i.id),
-        ) + 1;
-      const newIdentity = {
-        id: newId,
-        name: '',
-        url: '',
-        quality: 2,
-        icon: 'fas fa-link',
+      const placeholder = {
+        id: `placeholder-${Math.floor(Math.random() * 1e7)}`,
         disabled: true,
       };
-      this.identities.push(newIdentity);
+      this.identities.push(placeholder);
       return (
         this.createNewIdentity()
           .then(resp => {
-            const { id } = resp.data;
-            newIdentity.disabled = false;
-            newIdentity.id = id;
+            const insertAt = this.identities.indexOf(placeholder);
+            this.identities.splice(insertAt, 1, resp.data);
           })
           // TODO: display error state.
           .catch()
@@ -129,10 +119,7 @@ export default {
     },
     createNewIdentity() {
       const url = window.Urls['api:identity-list']();
-      const data = {
-        name: '',
-        url: '',
-      };
+      const data = {};
       return this.trackRequest(this.$http.post(url, data));
     },
     retrieveIdentities() {


### PR DESCRIPTION
Stop guessing at the ID.

In [a comment][1] on 95e8fcf14877525c3c2d758684019d1d403ffd05, Kit mentioned not liking the way that adding a new identity or alias had worked. Under the old system, the page:

1. Guessed an ID, in a way that was guaranteed to be unique within the page but not unique to the service,
2. Used that ID to create a disabled placeholder card in the UI, for immediate feedback to the user,
3. Submitted a POST to the service's API to create a "real" value with a service-wide ID, and
4. Replaced the placeholder's ID with the response ID, and enabled it to allow editing.

The service's identities and aliases APIs actually return full identity or alias data on POST, not just an ID. This replacement works slightly differently, by:

1. Generating an ID that's guaranteed to be invalid and very, very likely to be globally unique for the time it exists,
2. Creates a placeholder, as above,
3. POSTs to the API to create a real value, and
4. Replaces the disabled placeholder card with the value returned by the service.

I did a draft version of this change by splitting the page data model into Cards (which have a card ID, generated arbitrarily) and Identities/Aliases (which have all the API data), but it didn't buy much and complicated the design more than it was worth to me.

[1]: https://github.com/wlonk/wheretofind.me/commit/95e8fcf14877525c3c2d758684019d1d403ffd05#r37389162