### PR TITLE
brag open-source in footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -71,7 +71,7 @@
       <footer class="pt-4 my-md-5 pt-md-5 border-top" role="contentinfo">
         <div class="row">
           <div class="col-12 col-md text-center">
-            <small class="d-block mb-3">&copy; 2018-2019 Kit La Touche</small>
+            <small class="d-block">&copy; 2018-2020 Kit La Touche</small>
           </div>
         </div>
         <div class="row">
@@ -83,14 +83,18 @@
           <div class="col-12 col-md text-center">
             <small class="d-block mb-3">
               <a href="{% url "tos" %}">Terms of Service</a>
+              •
               <a href="{% url "about" %}">About</a>
             </small>
           </div>
         </div>
         <div class="row">
           <div class="col-12 col-md text-center">
-            <small class="d-block mb-3">
-              <a href="https://ko-fi.com/B0B586NC">Support us on Ko-fi</a>
+            <small class="d-block">
+              This website is <a href="https://github.com/wlonk/wheretofind.me"><span class="fab fa-github"></span> open-source</a>. <br>
+              Help us make it better by <a href="https://github.com/wlonk/wheretofind.me/issues">suggesting changes</a>. Or even better - implement them. </br>
+              <a href="{% url "user-profile" slug="kit" %}">Get in touch</a> if you have any problems or feedback. <br>
+              Or else, buy us <a href="https://ko-fi.com/B0B586NC"><span class="fas fa-mug-hot"></span> Ko-fi</a>
             </small>
           </div>
         </div>


### PR DESCRIPTION
There is only one mention of the source repository on the About page.
It should be obvious and evident that this is open source software by
putting links to GitHub and the GitHub issues list in the footer.

Also, makes some re-arragements to make the footer shorter in height.

I was about to send an email with suggestions for some changes, but
then I visited the wlonk's GitHub profile to find this repository.
I was happy that now I could make the changes myself and contribute
it upstream.

By the way, thank you so much for this amazing service. I have been
wondering how to keep a track of all the online identities I have.
wheretofind.me solves that problem for me. Now, I have this kind of
a ritual to cross-check whether any profile that I sign-in to, I have
it listed on my profile on wheretofind.me. That's the impact this
service has made on my life. So, thank you once again.