### PR TITLE
support more services

### DIFF
--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -180,6 +180,7 @@
               <option value="fab fa-twitter">Twitter</option>
               <option value="fab fa-untappd">Untappd</option>
               <option value="fab fa-vimeo">Vimeo</option>
+              <option value="fab fa-vk">VK</option>
               <option value="fab fa-youtube">YouTube</option>
             </select>
           </div>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -138,6 +138,7 @@
               <option value="fab fa-gitlab">Gitlab</option>
               <option value="fab fa-goodreads">Goodreads</option>
               <option value="fab fa-google-plus-g">Google Plus</option>
+              <option value="fab fa-hacker-news-square">HackerNews</option>
               <option value="fab fa-hackerrank">HackerRank</option>
               <option value="fab fa-instagram">Instagram</option>
               <option value="fab fa-keybase">Keybase</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -137,6 +137,7 @@
               <option value="fab fa-github">GitHub</option>
               <option value="fab fa-gitlab">Gitlab</option>
               <option value="fab fa-goodreads">Goodreads</option>
+              <option value="fab fa-google-play">Google Play</option>
               <option value="fab fa-google-plus-g">Google Plus</option>
               <option value="fab fa-hacker-news-square">HackerNews</option>
               <option value="fab fa-hackerrank">HackerRank</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -118,6 +118,7 @@
               <option value="fas fa-envelope">email</option>
               <option value="fab fa-500px">500px</option>
               <option value="fab fa-angellist">AngelList</option>
+              <option value="fab fa-bandcamp">BandCamp</option>
               <option value="fab fa-behance">Behance</option>
               <option value="fab fa-bitbucket">Bitbucket</option>
               <option value="fab fa-codepen">Codepen</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -151,6 +151,7 @@
               <option value="fab fa-stack-overflow">Stack Overflow</option>
               <option value="fab fa-steam">Steam</option>
               <option value="fab fa-teamspeak">Teamspeak</option>
+              <option value="fab fa-telegram-plane">Telegram</option>
               <option value="fab fa-tumblr">Tumblr</option>
               <option value="fab fa-twitch">Twitch</option>
               <option value="fab fa-twitter">Twitter</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -138,6 +138,7 @@
               <option value="fab fa-gitlab">Gitlab</option>
               <option value="fab fa-goodreads">Goodreads</option>
               <option value="fab fa-google-plus-g">Google Plus</option>
+              <option value="fab fa-hackerrank">HackerRank</option>
               <option value="fab fa-instagram">Instagram</option>
               <option value="fab fa-keybase">Keybase</option>
               <option value="fab fa-kickstarter">Kickstarter</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -132,6 +132,7 @@
               <option value="fab fa-etsy">Etsy</option>
               <option value="fab fa-facebook">Facebook</option>
               <option value="fab fa-figma">Figma</option>
+              <option value="fab fa-flickr">Flickr</option>
               <option value="fab fa-github">GitHub</option>
               <option value="fab fa-gitlab">Gitlab</option>
               <option value="fab fa-goodreads">Goodreads</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -164,7 +164,7 @@
               <option value="fab fa-skype">Skype</option>
               <option value="fab fa-slack">Slack</option>
               <option value="fab fa-slideshare">SlideShare</option>
-              <option value="fab fa-snapchat">Snapchat</option>
+              <option value="fab fa-snapchat-ghost">Snapchat</option>
               <option value="fab fa-soundcloud">Soundcloud</option>
               <option value="fab fa-stack-overflow">Stack Overflow</option>
               <option value="fab fa-steam">Steam</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -178,6 +178,7 @@
               <option value="fab fa-strava">Strava</option>
               <option value="fab fa-teamspeak">Teamspeak</option>
               <option value="fab fa-telegram-plane">Telegram</option>
+              <option value="fab fa-tiktok">Tiktok</option>
               <option value="fab fa-trello">Trello</option>
               <option value="fab fa-tripadvisor">Tripadvisor</option>
               <option value="fab fa-tumblr">Tumblr</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -121,6 +121,7 @@
               <option value="fab fa-bandcamp">BandCamp</option>
               <option value="fab fa-behance">Behance</option>
               <option value="fab fa-bitbucket">Bitbucket</option>
+              <option value="fab fa-blogger-b">Blogger</option>
               <option value="fab fa-codepen">Codepen</option>
               <option value="fab fa-deviantart">Deviantart</option>
               <option value="fab fa-diaspora">Diaspora</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -145,6 +145,7 @@
               <option value="fab fa-hacker-news-square">HackerNews</option>
               <option value="fab fa-hackerrank">HackerRank</option>
               <option value="fab fa-instagram">Instagram</option>
+              <option value="fab fa-itch-io">Itch.io</option>
               <option value="fab fa-jsfiddle">JSFiddle</option>
               <option value="fab fa-kaggle">Kaggle</option>
               <option value="fab fa-keybase">Keybase</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -158,6 +158,7 @@
               <option value="fab fa-pinterest">Pinterest</option>
               <option value="fa fa-pixelfed">Pixelfed</option>
               <option value="fab fa-product-hunt">Product Hunt</option>
+              <option value="fab fa-quora">Quora</option>
               <option value="fab fa-ravelry">Ravelry</option>
               <option value="fab fa-reddit">Reddit</option>
               <option value="fab fa-skype">Skype</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -174,6 +174,7 @@
               <option value="fab fa-teamspeak">Teamspeak</option>
               <option value="fab fa-telegram-plane">Telegram</option>
               <option value="fab fa-trello">Trello</option>
+              <option value="fab fa-tripadvisor">Tripadvisor</option>
               <option value="fab fa-tumblr">Tumblr</option>
               <option value="fab fa-twitch">Twitch</option>
               <option value="fab fa-twitter">Twitter</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -182,6 +182,7 @@
               <option value="fab fa-vimeo">Vimeo</option>
               <option value="fab fa-vk">VK</option>
               <option value="fab fa-wikipedia-w">Wikipedia</option>
+              <option value="fab fa-wordpress-simple">Wordpress</option>
               <option value="fab fa-youtube">YouTube</option>
             </select>
           </div>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -134,6 +134,7 @@
               <option value="fab fa-keybase">Keybase</option>
               <option value="fab fa-kickstarter">Kickstarter</option>
               <option value="fab fa-lastfm">Last</option>
+              <option value="fab fa-linkedin">LinkedIn</option>
               <option value="fab fa-mastodon">Mastodon</option>
               <option value="fa fa-matrix-org">Matrix</option>
               <option value="fab fa-medium">Medium</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -163,6 +163,7 @@
               <option value="fab fa-reddit">Reddit</option>
               <option value="fab fa-skype">Skype</option>
               <option value="fab fa-slack">Slack</option>
+              <option value="fab fa-slideshare">SlideShare</option>
               <option value="fab fa-snapchat">Snapchat</option>
               <option value="fab fa-soundcloud">Soundcloud</option>
               <option value="fab fa-stack-overflow">Stack Overflow</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -157,6 +157,7 @@
               <option value="fab fa-periscope">Periscope</option>
               <option value="fab fa-pinterest">Pinterest</option>
               <option value="fa fa-pixelfed">Pixelfed</option>
+              <option value="fab fa-product-hunt">Product Hunt</option>
               <option value="fab fa-ravelry">Ravelry</option>
               <option value="fab fa-reddit">Reddit</option>
               <option value="fab fa-skype">Skype</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -133,6 +133,7 @@
               <option value="fab fa-facebook">Facebook</option>
               <option value="fab fa-figma">Figma</option>
               <option value="fab fa-flickr">Flickr</option>
+              <option value="fab fa-foursquare">Foursquare</option>
               <option value="fab fa-github">GitHub</option>
               <option value="fab fa-gitlab">Gitlab</option>
               <option value="fab fa-goodreads">Goodreads</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -131,6 +131,7 @@
               <option value="fab fa-ello">Ello</option>
               <option value="fab fa-etsy">Etsy</option>
               <option value="fab fa-facebook">Facebook</option>
+              <option value="fab fa-figma">Figma</option>
               <option value="fab fa-github">GitHub</option>
               <option value="fab fa-gitlab">Gitlab</option>
               <option value="fab fa-goodreads">Goodreads</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -133,6 +133,7 @@
               <option value="fab fa-facebook">Facebook</option>
               <option value="fab fa-figma">Figma</option>
               <option value="fab fa-flickr">Flickr</option>
+              <option value="fab fa-flipboard">Flipboard</option>
               <option value="fab fa-foursquare">Foursquare</option>
               <option value="fab fa-github">GitHub</option>
               <option value="fab fa-gitlab">Gitlab</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -183,6 +183,7 @@
               <option value="fab fa-tumblr">Tumblr</option>
               <option value="fab fa-twitch">Twitch</option>
               <option value="fab fa-twitter">Twitter</option>
+              <option value="fab fa-unsplash">Unsplash</option>
               <option value="fab fa-untappd">Untappd</option>
               <option value="fab fa-vimeo">Vimeo</option>
               <option value="fab fa-vk">VK</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -173,6 +173,7 @@
               <option value="fab fa-strava">Strava</option>
               <option value="fab fa-teamspeak">Teamspeak</option>
               <option value="fab fa-telegram-plane">Telegram</option>
+              <option value="fab fa-trello">Trello</option>
               <option value="fab fa-tumblr">Tumblr</option>
               <option value="fab fa-twitch">Twitch</option>
               <option value="fab fa-twitter">Twitter</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -166,6 +166,7 @@
               <option value="fab fa-slideshare">SlideShare</option>
               <option value="fab fa-snapchat-ghost">Snapchat</option>
               <option value="fab fa-soundcloud">Soundcloud</option>
+              <option value="fab fa-spotify">Spotify</option>
               <option value="fab fa-stack-overflow">Stack Overflow</option>
               <option value="fab fa-steam">Steam</option>
               <option value="fab fa-teamspeak">Teamspeak</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -154,6 +154,7 @@
               <option value="fab fa-npm">NPM</option>
               <option value="fab fa-patreon">Patreon</option>
               <option value="fab fa-paypal">Paypal</option>
+              <option value="fab fa-periscope">Periscope</option>
               <option value="fab fa-pinterest">Pinterest</option>
               <option value="fa fa-pixelfed">Pixelfed</option>
               <option value="fab fa-ravelry">Ravelry</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -141,6 +141,7 @@
               <option value="fab fa-hacker-news-square">HackerNews</option>
               <option value="fab fa-hackerrank">HackerRank</option>
               <option value="fab fa-instagram">Instagram</option>
+              <option value="fab fa-jsfiddle">JSFiddle</option>
               <option value="fab fa-keybase">Keybase</option>
               <option value="fab fa-kickstarter">Kickstarter</option>
               <option value="fab fa-lastfm">Last</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -123,6 +123,7 @@
               <option value="fab fa-bitbucket">Bitbucket</option>
               <option value="fab fa-blogger-b">Blogger</option>
               <option value="fab fa-codepen">Codepen</option>
+              <option value="fab fa-dailymotion">DailyMotion</option>
               <option value="fab fa-dev">dev.to</option>
               <option value="fab fa-deviantart">Deviantart</option>
               <option value="fab fa-diaspora">Diaspora</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -172,6 +172,7 @@
               <option value="fab fa-snapchat-ghost">Snapchat</option>
               <option value="fab fa-soundcloud">Soundcloud</option>
               <option value="fab fa-spotify">Spotify</option>
+              <option value="fab fa-speakerdeck">Speaker Deck</option>
               <option value="fab fa-stack-exchange">Stack Exchange</option>
               <option value="fab fa-stack-overflow">Stack Overflow</option>
               <option value="fab fa-steam">Steam</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -142,6 +142,7 @@
               <option value="fab fa-hackerrank">HackerRank</option>
               <option value="fab fa-instagram">Instagram</option>
               <option value="fab fa-jsfiddle">JSFiddle</option>
+              <option value="fab fa-kaggle">Kaggle</option>
               <option value="fab fa-keybase">Keybase</option>
               <option value="fab fa-kickstarter">Kickstarter</option>
               <option value="fab fa-lastfm">Last</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -147,7 +147,7 @@
               <option value="fab fa-slack">Slack</option>
               <option value="fab fa-snapchat">Snapchat</option>
               <option value="fab fa-soundcloud">Soundcloud</option>
-              <option value="fab fa-stackoverflow">Stackoverflow</option>
+              <option value="fab fa-stack-overflow">Stack Overflow</option>
               <option value="fab fa-steam">Steam</option>
               <option value="fab fa-teamspeak">Teamspeak</option>
               <option value="fab fa-tumblr">Tumblr</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -137,6 +137,7 @@
               <option value="fab fa-github">GitHub</option>
               <option value="fab fa-gitlab">Gitlab</option>
               <option value="fab fa-goodreads">Goodreads</option>
+              <option value="fab fa-google-drive">Google Drive</option>
               <option value="fab fa-google-play">Google Play</option>
               <option value="fab fa-google-plus-g">Google Plus</option>
               <option value="fab fa-hacker-news-square">HackerNews</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -116,6 +116,7 @@
             >
               <option value="fas fa-link">web</option>
               <option value="fas fa-envelope">email</option>
+              <option value="fab fa-500px">500px</option>
               <option value="fab fa-angellist">AngelList</option>
               <option value="fab fa-behance">Behance</option>
               <option value="fab fa-bitbucket">Bitbucket</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -151,6 +151,7 @@
               <option value="fab fa-mastodon">Mastodon</option>
               <option value="fa fa-matrix-org">Matrix</option>
               <option value="fab fa-medium">Medium</option>
+              <option value="fab fa-npm">NPM</option>
               <option value="fab fa-patreon">Patreon</option>
               <option value="fab fa-paypal">Paypal</option>
               <option value="fab fa-pinterest">Pinterest</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -116,6 +116,7 @@
             >
               <option value="fas fa-link">web</option>
               <option value="fas fa-envelope">email</option>
+              <option value="fab fa-angellist">AngelList</option>
               <option value="fab fa-behance">Behance</option>
               <option value="fab fa-bitbucket">Bitbucket</option>
               <option value="fab fa-codepen">Codepen</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -123,6 +123,7 @@
               <option value="fab fa-bitbucket">Bitbucket</option>
               <option value="fab fa-blogger-b">Blogger</option>
               <option value="fab fa-codepen">Codepen</option>
+              <option value="fab fa-dev">dev.to</option>
               <option value="fab fa-deviantart">Deviantart</option>
               <option value="fab fa-diaspora">Diaspora</option>
               <option value="fab fa-discord">Discord</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -170,6 +170,7 @@
               <option value="fab fa-stack-exchange">Stack Exchange</option>
               <option value="fab fa-stack-overflow">Stack Overflow</option>
               <option value="fab fa-steam">Steam</option>
+              <option value="fab fa-strava">Strava</option>
               <option value="fab fa-teamspeak">Teamspeak</option>
               <option value="fab fa-telegram-plane">Telegram</option>
               <option value="fab fa-tumblr">Tumblr</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -146,6 +146,7 @@
               <option value="fab fa-keybase">Keybase</option>
               <option value="fab fa-kickstarter">Kickstarter</option>
               <option value="fab fa-lastfm">Last</option>
+              <option value="fab fa-leanpub">Leanpub</option>
               <option value="fab fa-linkedin">LinkedIn</option>
               <option value="fab fa-mastodon">Mastodon</option>
               <option value="fa fa-matrix-org">Matrix</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -167,6 +167,7 @@
               <option value="fab fa-snapchat-ghost">Snapchat</option>
               <option value="fab fa-soundcloud">Soundcloud</option>
               <option value="fab fa-spotify">Spotify</option>
+              <option value="fab fa-stack-exchange">Stack Exchange</option>
               <option value="fab fa-stack-overflow">Stack Overflow</option>
               <option value="fab fa-steam">Steam</option>
               <option value="fab fa-teamspeak">Teamspeak</option>

--- a/src/components/Identity.vue
+++ b/src/components/Identity.vue
@@ -181,6 +181,7 @@
               <option value="fab fa-untappd">Untappd</option>
               <option value="fab fa-vimeo">Vimeo</option>
               <option value="fab fa-vk">VK</option>
+              <option value="fab fa-wikipedia-w">Wikipedia</option>
               <option value="fab fa-youtube">YouTube</option>
             </select>
           </div>

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -76,6 +76,10 @@ const iconGuesses = [
     val: 'fab fa-flickr',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('flipboard.com'),
+    val: 'fab fa-flipboard',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('foursquare.com'),
     val: 'fab fa-foursquare',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -216,6 +216,10 @@ const iconGuesses = [
     val: 'fab fa-spotify',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('speakerdeck.com'),
+    val: 'fab fa-speakerdeck',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('stackexchange.com'),
     val: 'fab fa-stack-exchange',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -72,6 +72,10 @@ const iconGuesses = [
     val: 'fab fa-lastfm',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('linkedin.com'),
+    val: 'fa fa-linkedin',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('matrix.to'),
     val: 'fa fa-matrix-org',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -39,6 +39,10 @@ const iconGuesses = [
     val: 'fab fa-codepen',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('dailymotion.com'),
+    val: 'fab fa-dailymotion',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('dev.to'),
     val: 'fab fa-dev',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -68,6 +68,10 @@ const iconGuesses = [
     val: 'fab fa-figma',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('flickr.com'),
+    val: 'fab fa-flickr',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('github.com'),
     val: 'fab fa-github',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -96,6 +96,10 @@ const iconGuesses = [
     val: 'fab fa-instagram',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('jsfiddle.net'),
+    val: 'fab fa-jsfiddle',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('keybase.io'),
     val: 'fab fa-keybase',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -132,6 +132,10 @@ const iconGuesses = [
     val: 'fab fa-steam',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('t.me'),
+    val: 'fab fa-telegram-plane',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('teamspeak.com'),
     val: 'fab fa-teamspeak',
   },
@@ -167,6 +171,10 @@ const iconGuesses = [
   {
     fn: url => parseUrl(url).hostname.includes('mastodon'),
     val: 'fab fa-mastodon',
+  },
+  {
+    fn: url => parseUrl(url).hostname.includes('telegram'),
+    val: 'fab fa-telegram-plane',
   },
 
   { fn: url => parseUrl(url).protocol === 'mailto:', val: 'fas fa-envelope' },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -100,6 +100,10 @@ const iconGuesses = [
     val: 'fab fa-jsfiddle',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('kaggle.com'),
+    val: 'fab fa-kaggle',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('keybase.io'),
     val: 'fab fa-keybase',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -160,6 +160,10 @@ const iconGuesses = [
     val: 'fab fa-google-plus-g',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('quora.com'),
+    val: 'fab fa-quora',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('ravelry.com'),
     val: 'fab fa-ravelry',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -144,6 +144,10 @@ const iconGuesses = [
     val: 'fab fa-patreon',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('periscope.tv'),
+    val: 'fab fa-periscope',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('pinterest.com'),
     val: 'fab fa-pinterest',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -192,6 +192,10 @@ const iconGuesses = [
     val: 'fab fa-soundcloud',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('spotify.com'),
+    val: 'fab fa-spotify',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('stackoverflow.com'),
     val: 'fab fa-stack-overflow',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -220,6 +220,10 @@ const iconGuesses = [
     val: 'fab fa-teamspeak',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('trello.com'),
+    val: 'fab fa-trello',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('tumblr.com'),
     val: 'fab fa-tumblr',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -64,6 +64,10 @@ const iconGuesses = [
     val: 'fab fa-facebook',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('figma.com'),
+    val: 'fab fa-figma',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('github.com'),
     val: 'fab fa-github',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -180,6 +180,10 @@ const iconGuesses = [
     val: 'fab fa-slack',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('slideshare.net'),
+    val: 'fab fa-slideshare',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('snapchat.com'),
     val: 'fab fa-snapchat',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -88,6 +88,10 @@ const iconGuesses = [
     val: 'fab fa-goodreads',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('hackerrank.com'),
+    val: 'fab fa-hackerrank',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('instagram.com'),
     val: 'fab fa-instagram',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -108,6 +108,10 @@ const iconGuesses = [
     val: 'fab fa-instagram',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('itch.io'),
+    val: 'fab fa-itch-io',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('jsfiddle.net'),
     val: 'fab fa-jsfiddle',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -252,6 +252,10 @@ const iconGuesses = [
     val: 'fab fa-vk',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('wikipedia.org'),
+    val: 'fab fa-wikipedia-w',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('youtube.com'),
     val: 'fab fa-youtube',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -196,6 +196,10 @@ const iconGuesses = [
     val: 'fab fa-spotify',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('stackexchange.com'),
+    val: 'fab fa-stack-exchange',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('stackoverflow.com'),
     val: 'fab fa-stack-overflow',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -7,6 +7,10 @@ function parseUrl(url) {
 const iconGuesses = [
   { fn: () => true, val: 'fas fa-link' },
   {
+    fn: url => parseUrl(url).hostname.endsWith('angel.co'),
+    val: 'fab fa-angellist',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('behance.net'),
     val: 'fab fa-behance',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -15,6 +15,10 @@ const iconGuesses = [
     val: 'fab fa-angellist',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('bandcamp.com'),
+    val: 'fab fa-bandcamp',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('behance.net'),
     val: 'fab fa-behance',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -208,6 +208,10 @@ const iconGuesses = [
     val: 'fab fa-steam',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('strava.com'),
+    val: 'fab fa-strava',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('t.me'),
     val: 'fab fa-telegram-plane',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -248,6 +248,10 @@ const iconGuesses = [
     val: 'fab fa-vimeo',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('vk.com'),
+    val: 'fab fa-vk',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('youtube.com'),
     val: 'fab fa-youtube',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -280,6 +280,10 @@ const iconGuesses = [
     fn: url => parseUrl(url).hostname.includes('telegram'),
     val: 'fab fa-telegram-plane',
   },
+  {
+    fn: url => parseUrl(url).hostname.includes('wordpress'),
+    val: 'fab fa-wordpress-simple',
+  },
 
   { fn: url => parseUrl(url).protocol === 'mailto:', val: 'fas fa-envelope' },
 ];

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -120,6 +120,10 @@ const iconGuesses = [
     val: 'fab fa-medium',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('news.ycombinator.com'),
+    val: 'fab fa-hacker-news-square',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('patreon.com'),
     val: 'fab fa-patreon',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -185,7 +185,7 @@ const iconGuesses = [
   },
   {
     fn: url => parseUrl(url).hostname.endsWith('snapchat.com'),
-    val: 'fab fa-snapchat',
+    val: 'fab fa-snapchat-ghost',
   },
   {
     fn: url => parseUrl(url).hostname.endsWith('soundcloud.com'),

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -224,6 +224,10 @@ const iconGuesses = [
     val: 'fab fa-trello',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('tripadvisor.com'),
+    val: 'fab fa-tripadvisor',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('tumblr.com'),
     val: 'fab fa-tumblr',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -229,6 +229,10 @@ const iconGuesses = [
     val: 'fab fa-paypal',
   },
   {
+    fn: url => parseUrl(url).hostname.includes('pixelfed'),
+    val: 'fa fa-pixelfed',
+  },
+  {
     fn: url => parseUrl(url).hostname.includes('pora'),
     val: 'fab fa-diaspora',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -136,6 +136,10 @@ const iconGuesses = [
     val: 'fab fa-hacker-news-square',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('npmjs.com'),
+    val: 'fab fa-npm',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('patreon.com'),
     val: 'fab fa-patreon',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -156,6 +156,10 @@ const iconGuesses = [
     val: 'fab fa-product-hunt',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('play.google.com'),
+    val: 'fab fa-google-play',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('plus.google.com'),
     val: 'fab fa-google-plus-g',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -116,6 +116,10 @@ const iconGuesses = [
     val: 'fab fa-lastfm',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('leanpub.com'),
+    val: 'fab fa-leanpub',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('linkedin.com'),
     val: 'fa fa-linkedin',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -88,10 +88,6 @@ const iconGuesses = [
     val: 'fab fa-patreon',
   },
   {
-    fn: url => parseUrl(url).hostname.endsWith('paypal.com'),
-    val: 'fab fa-paypal',
-  },
-  {
     fn: url => parseUrl(url).hostname.endsWith('pinterest.com'),
     val: 'fab fa-pinterest',
   },
@@ -164,6 +160,10 @@ const iconGuesses = [
     val: 'fab fa-youtube',
   },
 
+  {
+    fn: url => parseUrl(url).hostname.includes('paypal'),
+    val: 'fab fa-paypal',
+  },
   {
     fn: url => parseUrl(url).hostname.includes('pora'),
     val: 'fab fa-diaspora',

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -260,6 +260,10 @@ const iconGuesses = [
     val: 'fab fa-twitter',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('unsplash.com'),
+    val: 'fab fa-unsplash',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('untappd.com'),
     val: 'fab fa-untappd',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -24,7 +24,11 @@ const iconGuesses = [
   },
   {
     fn: url => parseUrl(url).hostname.endsWith('blogger.com'),
-    val: 'fab fa-blogger',
+    val: 'fab fa-blogger-b',
+  },
+  {
+    fn: url => parseUrl(url).hostname.endsWith('blogspot.com'),
+    val: 'fab fa-blogger-b',
   },
   {
     fn: url => parseUrl(url).hostname.endsWith('bitbucket.org'),

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -39,6 +39,10 @@ const iconGuesses = [
     val: 'fab fa-codepen',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('dev.to'),
+    val: 'fab fa-dev',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('deviantart.com'),
     val: 'fab fa-deviantart',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -72,6 +72,10 @@ const iconGuesses = [
     val: 'fab fa-flickr',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('foursquare.com'),
+    val: 'fab fa-foursquare',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('github.com'),
     val: 'fab fa-github',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -7,6 +7,10 @@ function parseUrl(url) {
 const iconGuesses = [
   { fn: () => true, val: 'fas fa-link' },
   {
+    fn: url => parseUrl(url).hostname.endsWith('500px.com'),
+    val: 'fab fa-500px',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('angel.co'),
     val: 'fab fa-angellist',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -72,6 +72,10 @@ const iconGuesses = [
     val: 'fab fa-lastfm',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('matrix.to'),
+    val: 'fa fa-matrix-org',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('medium.com'),
     val: 'fab fa-medium',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -121,7 +121,7 @@ const iconGuesses = [
   },
   {
     fn: url => parseUrl(url).hostname.endsWith('stackoverflow.com'),
-    val: 'fab fa-stackoverflow',
+    val: 'fab fa-stack-overflow',
   },
   {
     fn: url => parseUrl(url).hostname.endsWith('steamcommunity.com'),

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -54,6 +54,10 @@ const iconGuesses = [
     fn: url => parseUrl(url).hostname.endsWith('dribbble.com'),
     val: 'fab fa-dribbble',
   },
+  {
+    fn: url => parseUrl(url).hostname.endsWith('drive.google.com'),
+    val: 'fab fa-google-drive',
+  },
   { fn: url => parseUrl(url).hostname.endsWith('ello.co'), val: 'fab fa-ello' },
   {
     fn: url => parseUrl(url).hostname.endsWith('etsy.com'),

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -152,6 +152,10 @@ const iconGuesses = [
     val: 'fab fa-pinterest',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('producthunt.com'),
+    val: 'fab fa-product-hunt',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('plus.google.com'),
     val: 'fab fa-google-plus-g',
   },

--- a/src/iconGuesses.js
+++ b/src/iconGuesses.js
@@ -240,6 +240,10 @@ const iconGuesses = [
     val: 'fab fa-teamspeak',
   },
   {
+    fn: url => parseUrl(url).hostname.endsWith('tiktok.com'),
+    val: 'fab fa-tiktok',
+  },
+  {
     fn: url => parseUrl(url).hostname.endsWith('trello.com'),
     val: 'fab fa-trello',
   },

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,7 @@
       We use FontAwesome for most of our service icons, and Fork Awesome for a
       few that are not in FontAwesome, such as Matrix/Riot and Pixelfed.
     -->
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.0/css/all.css" integrity="sha384-OLYO0LymqQ+uHXELyx93kblK5YIS3B2ZfLGBmsJaUyor7CpMTBsahDHByqSuWW+q" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.1.7/css/fork-awesome.min.css" integrity="sha256-gsmEoJAws/Kd3CjuOQzLie5Q3yshhvmo7YNtBG7aaEY=" crossorigin="anonymous">
     <!-- Custom styles for this template -->
     <link href="{% static "css/app.css" %}" rel="stylesheet">

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -131,6 +131,8 @@ ICONS = defaultdict(
         "www.slideshare.net": "fab fa-slideshare",
         "spotify.com": "fab fa-spotify",
         "open.spotify.com": "fab fa-spotify",
+        "stackexchange.com": "fab fa-stack-exchange",
+        "www.stackexchange.com": "fab fa-stack-exchange",
     },
 )
 
@@ -188,6 +190,7 @@ ICON_CHOICES = (
     ("fab fa-snapchat-ghost", "fab fa-snapchat-ghost"),  # Snapchat
     ("fab fa-soundcloud", "fab fa-soundcloud"),  # Soundcloud
     ("fab fa-spotify", "fab fa-spotify"),  # Spotify
+    ("fab fa-stack-exchange", "fab fa-stack-exchange"),  # Stack Exchange
     ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
     ("fab fa-steam", "fab fa-steam"),  # Steam
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
@@ -254,6 +257,7 @@ ICON_HUMAN_NAMES = {
     "snapchat-ghost": "Snapchat",
     "soundcloud": "Soundcloud",
     "spotify": "Spotify",
+    "stack-exchange": "Stack Exchange",
     "stack-overflow": "Stack Overflow",
     "steam": "Steam",
     "teamspeak": "Teamspeak",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -135,6 +135,8 @@ ICONS = defaultdict(
         "www.stackexchange.com": "fab fa-stack-exchange",
         "strava.com": "fab fa-strava",
         "www.strava.com": "fab fa-strava",
+        "trello.com": "fab fa-trello",
+        "www.trello.com": "fab fa-trello",
     },
 )
 
@@ -198,6 +200,7 @@ ICON_CHOICES = (
     ("fab fa-strava", "fab fa-strava"),  # Strava
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
     ("fab fa-telegram-plane", "fab fa-telegram-plane"),  # Telegram
+    ("fab fa-trello", "fab fa-trello"),  # Trello
     ("fab fa-tumblr", "fab fa-tumblr"),  # Tumblr
     ("fab fa-twitch", "fab fa-twitch"),  # Twitch
     ("fab fa-twitter", "fab fa-twitter"),  # Twitter
@@ -266,6 +269,7 @@ ICON_HUMAN_NAMES = {
     "strava": "Strava",
     "teamspeak": "Teamspeak",
     "telegram-plane": "Telegram",
+    "trello": "Trello",
     "tumblr": "Tumblr",
     "twitch": "Twitch",
     "twitter": "Twitter",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -139,6 +139,8 @@ ICONS = defaultdict(
         "www.trello.com": "fab fa-trello",
         "tripadvisor.com": "fab fa-tripadvisor",
         "www.tripadvisor.com": "fab fa-tripadvisor",
+        "vk.com": "fab fa-vk",
+        "www.vk.com": "fab fa-vk",
     },
 )
 
@@ -209,6 +211,7 @@ ICON_CHOICES = (
     ("fab fa-twitter", "fab fa-twitter"),  # Twitter
     ("fab fa-untappd", "fab fa-untappd"),  # Untappd
     ("fab fa-vimeo", "fab fa-vimeo"),  # Vimeo
+    ("fab fa-vk", "fab fa-vk"),  # VK
     ("fab fa-youtube", "fab fa-youtube"),  # YouTube
 )
 
@@ -279,6 +282,7 @@ ICON_HUMAN_NAMES = {
     "twitter": "Twitter",
     "untappd": "Untappd",
     "vimeo": "Vimeo",
+    "vk": "VK",
     "youtube": "YouTube",
 }
 

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -148,6 +148,8 @@ ICONS = defaultdict(
         "drive.google.com": "fab fa-google-drive",
         "flipboard.com": "fab fa-flipboard",
         "www.flipboard.com": "fab fa-flipboard",
+        "dailymotion.com": "fab fa-dailymotion",
+        "www.dailymotion.com": "fab fa-dailymotion",
     },
 )
 
@@ -161,6 +163,7 @@ ICON_CHOICES = (
     ("fab fa-bitbucket", "fab fa-bitbucket"),  # Bitbucket
     ("fab fa-blogger-b", "fab fa-blogger-b"),  # Blogger
     ("fab fa-codepen", "fab fa-codepen"),  # Codepen
+    ("fab fa-dailymotion", "fab fa-dailymotion"),  # DailyMotion
     ("fab fa-dev", "fab fa-dev"),  # DEV.to
     ("fab fa-deviantart", "fab fa-deviantart"),  # Deviantart
     ("fab fa-diaspora", "fab fa-diaspora"),  # Diaspora
@@ -237,6 +240,7 @@ ICON_HUMAN_NAMES = {
     "bitbucket": "Bitbucket",
     "blogger-b": "Blogger",
     "codepen": "Codepen",
+    "dailymotion": "DailyMotion",
     "dev": "DEV.to",
     "deviantart": "Deviantart",
     "diaspora": "Diaspora",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -127,6 +127,8 @@ ICONS = defaultdict(
         "www.producthunt.com": "fab fa-product-hunt",
         "quora.com": "fab fa-quora",
         "www.quora.com": "fab fa-quora",
+        "slideshare.net": "fab fa-slideshare",
+        "www.slideshare.net": "fab fa-slideshare",
     },
 )
 
@@ -180,6 +182,7 @@ ICON_CHOICES = (
     ("fab fa-reddit", "fab fa-reddit"),  # Reddit
     ("fab fa-skype", "fab fa-skype"),  # Skype
     ("fab fa-slack", "fab fa-slack"),  # Slack
+    ("fab fa-slideshare", "fab fa-slideshare"),  # SlideShare
     ("fab fa-snapchat", "fab fa-snapchat"),  # Snapchat
     ("fab fa-soundcloud", "fab fa-soundcloud"),  # Soundcloud
     ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
@@ -244,6 +247,7 @@ ICON_HUMAN_NAMES = {
     "reddit": "Reddit",
     "skype": "Skype",
     "slack": "Slack",
+    "slideshare": "SlideShare",
     "snapchat": "Snapchat",
     "soundcloud": "Soundcloud",
     "stack-overflow": "Stack Overflow",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -96,12 +96,15 @@ ICONS = defaultdict(
         "www.paypal.me": "fab fa-paypal",
         "angel.co": "fab fa-angellist",
         "www.angel.co": "fab fa-angellist",
+        "500px.com": "fab fa-500px",
+        "www.500px.com": "fab fa-500px",
     },
 )
 
 ICON_CHOICES = (
     ("fas fa-link", "fas fa-link"),  # web
     ("fas fa-envelope", "fas fa-envelope"),  # email
+    ("fab fa-500px", "fab fa-500px"),  # 500px
     ("fab fa-angellist", "fab fa-angellist"),  # AngelList
     ("fab fa-behance", "fab fa-behance"),  # Behance
     ("fab fa-bitbucket", "fab fa-bitbucket"),  # Bitbucket
@@ -150,6 +153,7 @@ ICON_CHOICES = (
 ICON_HUMAN_NAMES = {
     "link": "web",
     "envelope": "email",
+    "500px": "500px",
     "angellist": "AngelList",
     "behance": "Behance",
     "bitbucket": "Bitbucket",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -115,6 +115,8 @@ ICONS = defaultdict(
         "www.hackerrank.com": "fab fa-hackerrank",
         "jsfiddle.net": "fab fa-jsfiddle",
         "www.jsfiddle.net": "fab fa-jsfiddle",
+        "kaggle.com": "fab fa-kaggle",
+        "www.kaggle.com": "fab fa-kaggle",
     },
 )
 
@@ -147,6 +149,7 @@ ICON_CHOICES = (
     ("fab fa-hackerrank", "fab fa-hackerrank"),  # HackerRank
     ("fab fa-instagram", "fab fa-instagram"),  # Instagram
     ("fab fa-jsfiddle", "fab fa-jsfiddle"),  # JSFiddle
+    ("fab fa-kaggle", "fab fa-kaggle"),  # Kaggle
     ("fab fa-keybase", "fab fa-keybase"),  # Keybase
     ("fab fa-kickstarter", "fab fa-kickstarter"),  # Kickstarter
     ("fab fa-lastfm", "fab fa-lastfm"),  # Last
@@ -205,6 +208,7 @@ ICON_HUMAN_NAMES = {
     "hackerrank": "HackerRank",
     "instagram": "Instagram",
     "jsfiddle": "JSFiddle",
+    "kaggle": "Kaggle",
     "keybase": "Keybase",
     "kickstarter": "Kickstarter",
     "lastfm": "Last",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -141,6 +141,8 @@ ICONS = defaultdict(
         "www.tripadvisor.com": "fab fa-tripadvisor",
         "vk.com": "fab fa-vk",
         "www.vk.com": "fab fa-vk",
+        "wikipedia.org": "fab fa-wikipedia-w",
+        "en.wikipedia.org": "fab fa-wikipedia-w",
     },
 )
 
@@ -212,6 +214,7 @@ ICON_CHOICES = (
     ("fab fa-untappd", "fab fa-untappd"),  # Untappd
     ("fab fa-vimeo", "fab fa-vimeo"),  # Vimeo
     ("fab fa-vk", "fab fa-vk"),  # VK
+    ("fab fa-wikipedia-w", "fab fa-wikipedia-w"),  # Wikipedia
     ("fab fa-youtube", "fab fa-youtube"),  # YouTube
 )
 
@@ -283,6 +286,7 @@ ICON_HUMAN_NAMES = {
     "untappd": "Untappd",
     "vimeo": "Vimeo",
     "vk": "VK",
+    "wikipedia-w": "Wikipedia",
     "youtube": "YouTube",
 }
 

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -145,6 +145,7 @@ ICONS = defaultdict(
         "en.wikipedia.org": "fab fa-wikipedia-w",
         "wordpress.com": "fab fa-wordpress-simple",
         "play.google.com": "fab fa-google-play",
+        "drive.google.com": "fab fa-google-drive",
     },
 )
 
@@ -172,6 +173,7 @@ ICON_CHOICES = (
     ("fab fa-github", "fab fa-github"),  # GitHub
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
     ("fab fa-goodreads", "fab fa-goodreads"),  # Goodreads
+    ("fab fa-google-drive", "fab fa-google-drive"),  # Google Drive
     ("fab fa-google-play", "fab fa-google-play"),  # Google Play
     ("fab fa-google-plus-g", "fab fa-google-plus-g"),  # Google Plus
     ("fab fa-hacker-news-square", "fab fa-hacker-news-square"),  # HackerNews
@@ -246,6 +248,7 @@ ICON_HUMAN_NAMES = {
     "github": "GitHub",
     "gitlab": "Gitlab",
     "goodreads": "Goodreads",
+    "google-drive": "Google Drive",
     "google-play": "Google Play",
     "google-plus-g": "Google Plus",
     "hacker-news-square": "Hacker News",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -117,6 +117,8 @@ ICONS = defaultdict(
         "www.jsfiddle.net": "fab fa-jsfiddle",
         "kaggle.com": "fab fa-kaggle",
         "www.kaggle.com": "fab fa-kaggle",
+        "leanpub.com": "fab fa-leanpub",
+        "www.leanpub.com": "fab fa-leanpub",
     },
 )
 
@@ -153,6 +155,7 @@ ICON_CHOICES = (
     ("fab fa-keybase", "fab fa-keybase"),  # Keybase
     ("fab fa-kickstarter", "fab fa-kickstarter"),  # Kickstarter
     ("fab fa-lastfm", "fab fa-lastfm"),  # Last
+    ("fab fa-leanpub", "fab fa-leanpub"),  # Leanpub
     ("fab fa-linkedin", "fab fa-linkedin"),  # LinkedIn
     ("fab fa-mastodon", "fab fa-mastodon"),  # Mastodon
     ("fa fa-matrix-org", "fa fa-matrix-org"),  # Matrix
@@ -212,6 +215,7 @@ ICON_HUMAN_NAMES = {
     "keybase": "Keybase",
     "kickstarter": "Kickstarter",
     "lastfm": "Last",
+    "leanpub": "Leanpub",
     "linkedin": "LinkedIn",
     "mastodon": "Mastodon",
     "matrix-org": "Matrix",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -153,6 +153,8 @@ ICONS = defaultdict(
         "itch.io": "fab fa-itch-io",
         "unsplash.com": "fab fa-unsplash",
         "www.unsplash.com": "fab fa-unsplash",
+        "tiktok.com": "fab fa-tiktok",
+        "www.tiktok.com": "fab fa-tiktok",
     },
 )
 
@@ -221,6 +223,7 @@ ICON_CHOICES = (
     ("fab fa-strava", "fab fa-strava"),  # Strava
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
     ("fab fa-telegram-plane", "fab fa-telegram-plane"),  # Telegram
+    ("fab fa-tiktok", "fab fa-tiktok"),  # Tiktok
     ("fab fa-trello", "fab fa-trello"),  # Trello
     ("fab fa-tripadvisor", "fab fa-tripadvisor"),  # Trip Advisor
     ("fab fa-tumblr", "fab fa-tumblr"),  # Tumblr
@@ -300,6 +303,7 @@ ICON_HUMAN_NAMES = {
     "strava": "Strava",
     "teamspeak": "Teamspeak",
     "telegram-plane": "Telegram",
+    "tiktok": "Tiktok",
     "trello": "Trello",
     "tripadvisor": "Trip Advisor",
     "tumblr": "Tumblr",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -55,8 +55,8 @@ ICONS = defaultdict(
         "www.teamspeak.com": "fab fa-teamspeak",
         "steamcommunity.com": "fab fa-steam",
         "www.steamcommunity.com": "fab fa-steam",
-        "stackoverflow.com": "fab fa-stackoverflow",
-        "www.stackoverflow.com": "fab fa-stackoverflow",
+        "stackoverflow.com": "fab fa-stack-overflow",
+        "www.stackoverflow.com": "fab fa-stack-overflow",
         "soundcloud.com": "fab fa-soundcloud",
         "www.soundcloud.com": "fab fa-soundcloud",
         "snapchat.com": "fab fa-snapchat",
@@ -128,7 +128,7 @@ ICON_CHOICES = (
     ("fab fa-slack", "fab fa-slack"),  # Slack
     ("fab fa-snapchat", "fab fa-snapchat"),  # Snapchat
     ("fab fa-soundcloud", "fab fa-soundcloud"),  # Soundcloud
-    ("fab fa-stackoverflow", "fab fa-stackoverflow"),  # Stackoverflow
+    ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
     ("fab fa-steam", "fab fa-steam"),  # Steam
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
     ("fab fa-tumblr", "fab fa-tumblr"),  # Tumblr
@@ -175,7 +175,7 @@ ICON_HUMAN_NAMES = {
     "slack": "Slack",
     "snapchat": "Snapchat",
     "soundcloud": "Soundcloud",
-    "stackoverflow": "Stackoverflow",
+    "stack-overflow": "Stack Overflow",
     "steam": "Steam",
     "teamspeak": "Teamspeak",
     "tumblr": "Tumblr",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -121,6 +121,8 @@ ICONS = defaultdict(
         "www.leanpub.com": "fab fa-leanpub",
         "npmjs.com": "fab fa-npm",
         "www.npmjs.com": "fab fa-npm",
+        "periscope.tv": "fab fa-periscope",
+        "www.periscope.tv": "fab fa-periscope",
     },
 )
 
@@ -165,6 +167,7 @@ ICON_CHOICES = (
     ("fab fa-npm", "fab fa-npm"),  # NPM
     ("fab fa-patreon", "fab fa-patreon"),  # Patreon
     ("fab fa-paypal", "fab fa-paypal"),  # Paypal
+    ("fab fa-periscope", "fab fa-periscope"),  # Periscope
     ("fab fa-pinterest", "fab fa-pinterest"),  # Pinterest
     ("fa fa-pixelfed", "fa fa-pixelfed"),  # Pixelfed
     ("fab fa-ravelry", "fab fa-ravelry"),  # Ravelry
@@ -226,6 +229,7 @@ ICON_HUMAN_NAMES = {
     "npm": "NPM",
     "patreon": "Patreon",
     "paypal": "Paypal",
+    "periscope": "Periscope",
     "pinterest": "Pinterest",
     "pixelfed": "Pixelfed",
     "ravelry": "Ravelry",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -94,12 +94,15 @@ ICONS = defaultdict(
         "www.linkedin.com": "fab fa-linkedin",
         "paypal.me": "fab fa-paypal",
         "www.paypal.me": "fab fa-paypal",
+        "angel.co": "fab fa-angellist",
+        "www.angel.co": "fab fa-angellist",
     },
 )
 
 ICON_CHOICES = (
     ("fas fa-link", "fas fa-link"),  # web
     ("fas fa-envelope", "fas fa-envelope"),  # email
+    ("fab fa-angellist", "fab fa-angellist"),  # AngelList
     ("fab fa-behance", "fab fa-behance"),  # Behance
     ("fab fa-bitbucket", "fab fa-bitbucket"),  # Bitbucket
     ("fab fa-codepen", "fab fa-codepen"),  # Codepen
@@ -147,6 +150,7 @@ ICON_CHOICES = (
 ICON_HUMAN_NAMES = {
     "link": "web",
     "envelope": "email",
+    "angellist": "AngelList",
     "behance": "Behance",
     "bitbucket": "Bitbucket",
     "codepen": "Codepen",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -123,6 +123,8 @@ ICONS = defaultdict(
         "www.npmjs.com": "fab fa-npm",
         "periscope.tv": "fab fa-periscope",
         "www.periscope.tv": "fab fa-periscope",
+        "producthunt.com": "fab fa-product-hunt",
+        "www.producthunt.com": "fab fa-product-hunt",
     },
 )
 
@@ -170,6 +172,7 @@ ICON_CHOICES = (
     ("fab fa-periscope", "fab fa-periscope"),  # Periscope
     ("fab fa-pinterest", "fab fa-pinterest"),  # Pinterest
     ("fa fa-pixelfed", "fa fa-pixelfed"),  # Pixelfed
+    ("fab fa-product-hunt", "fab fa-product-hunt"),  # Product Hunt
     ("fab fa-ravelry", "fab fa-ravelry"),  # Ravelry
     ("fab fa-reddit", "fab fa-reddit"),  # Reddit
     ("fab fa-skype", "fab fa-skype"),  # Skype
@@ -232,6 +235,7 @@ ICON_HUMAN_NAMES = {
     "periscope": "Periscope",
     "pinterest": "Pinterest",
     "pixelfed": "Pixelfed",
+    "product-hunt": "Product Hunt",
     "ravelry": "Ravelry",
     "reddit": "Reddit",
     "skype": "Skype",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -106,6 +106,8 @@ ICONS = defaultdict(
         "www.dev.to": "fab fa-dev",
         "figma.com": "fab fa-figma",
         "www.figma.com": "fab fa-figma",
+        "flickr.com": "fab fa-flickr",
+        "www.flickr.com": "fab fa-flickr",
     },
 )
 
@@ -128,6 +130,7 @@ ICON_CHOICES = (
     ("fab fa-etsy", "fab fa-etsy"),  # Etsy
     ("fab fa-facebook", "fab fa-facebook"),  # Facebook
     ("fab fa-figma", "fab fa-figma"),  # Figma
+    ("fab fa-flickr", "fab fa-flickr"),  # Flickr
     ("fab fa-github", "fab fa-github"),  # GitHub
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
     ("fab fa-goodreads", "fab fa-goodreads"),  # Goodreads
@@ -181,6 +184,7 @@ ICON_HUMAN_NAMES = {
     "etsy": "Etsy",
     "facebook": "Facebook",
     "figma": "Figma",
+    "flickr": "Flickr",
     "github": "GitHub",
     "gitlab": "Gitlab",
     "goodreads": "Goodreads",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -137,6 +137,8 @@ ICONS = defaultdict(
         "www.strava.com": "fab fa-strava",
         "trello.com": "fab fa-trello",
         "www.trello.com": "fab fa-trello",
+        "tripadvisor.com": "fab fa-tripadvisor",
+        "www.tripadvisor.com": "fab fa-tripadvisor",
     },
 )
 
@@ -201,6 +203,7 @@ ICON_CHOICES = (
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
     ("fab fa-telegram-plane", "fab fa-telegram-plane"),  # Telegram
     ("fab fa-trello", "fab fa-trello"),  # Trello
+    ("fab fa-tripadvisor", "fab fa-tripadvisor"),  # Trip Advisor
     ("fab fa-tumblr", "fab fa-tumblr"),  # Tumblr
     ("fab fa-twitch", "fab fa-twitch"),  # Twitch
     ("fab fa-twitter", "fab fa-twitter"),  # Twitter
@@ -270,6 +273,7 @@ ICON_HUMAN_NAMES = {
     "teamspeak": "Teamspeak",
     "telegram-plane": "Telegram",
     "trello": "Trello",
+    "tripadvisor": "Trip Advisor",
     "tumblr": "Tumblr",
     "twitch": "Twitch",
     "twitter": "Twitter",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -59,8 +59,8 @@ ICONS = defaultdict(
         "www.stackoverflow.com": "fab fa-stack-overflow",
         "soundcloud.com": "fab fa-soundcloud",
         "www.soundcloud.com": "fab fa-soundcloud",
-        "snapchat.com": "fab fa-snapchat",
-        "www.snapchat.com": "fab fa-snapchat",
+        "snapchat.com": "fab fa-snapchat-ghost",
+        "www.snapchat.com": "fab fa-snapchat-ghost",
         "slack.com": "fab fa-slack",
         "www.slack.com": "fab fa-slack",
         "skype.com": "fab fa-skype",
@@ -183,7 +183,7 @@ ICON_CHOICES = (
     ("fab fa-skype", "fab fa-skype"),  # Skype
     ("fab fa-slack", "fab fa-slack"),  # Slack
     ("fab fa-slideshare", "fab fa-slideshare"),  # SlideShare
-    ("fab fa-snapchat", "fab fa-snapchat"),  # Snapchat
+    ("fab fa-snapchat-ghost", "fab fa-snapchat-ghost"),  # Snapchat
     ("fab fa-soundcloud", "fab fa-soundcloud"),  # Soundcloud
     ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
     ("fab fa-steam", "fab fa-steam"),  # Steam
@@ -248,7 +248,7 @@ ICON_HUMAN_NAMES = {
     "skype": "Skype",
     "slack": "Slack",
     "slideshare": "SlideShare",
-    "snapchat": "Snapchat",
+    "snapchat-ghost": "Snapchat",
     "soundcloud": "Soundcloud",
     "stack-overflow": "Stack Overflow",
     "steam": "Steam",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -119,6 +119,8 @@ ICONS = defaultdict(
         "www.kaggle.com": "fab fa-kaggle",
         "leanpub.com": "fab fa-leanpub",
         "www.leanpub.com": "fab fa-leanpub",
+        "npmjs.com": "fab fa-npm",
+        "www.npmjs.com": "fab fa-npm",
     },
 )
 
@@ -160,6 +162,7 @@ ICON_CHOICES = (
     ("fab fa-mastodon", "fab fa-mastodon"),  # Mastodon
     ("fa fa-matrix-org", "fa fa-matrix-org"),  # Matrix
     ("fab fa-medium", "fab fa-medium"),  # Medium
+    ("fab fa-npm", "fab fa-npm"),  # NPM
     ("fab fa-patreon", "fab fa-patreon"),  # Patreon
     ("fab fa-paypal", "fab fa-paypal"),  # Paypal
     ("fab fa-pinterest", "fab fa-pinterest"),  # Pinterest
@@ -220,6 +223,7 @@ ICON_HUMAN_NAMES = {
     "mastodon": "Mastodon",
     "matrix-org": "Matrix",
     "medium": "Medium",
+    "npm": "NPM",
     "patreon": "Patreon",
     "paypal": "Paypal",
     "pinterest": "Pinterest",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -110,6 +110,7 @@ ICONS = defaultdict(
         "www.flickr.com": "fab fa-flickr",
         "foursquare.com": "fab fa-foursquare",
         "www.foursquare.com": "fab fa-foursquare",
+        "news.ycombinator.com": "fab fa-hacker-news-square",
         "hackerrank.com": "fab fa-hackerrank",
         "www.hackerrank.com": "fab fa-hackerrank",
     },
@@ -140,6 +141,7 @@ ICON_CHOICES = (
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
     ("fab fa-goodreads", "fab fa-goodreads"),  # Goodreads
     ("fab fa-google-plus-g", "fab fa-google-plus-g"),  # Google Plus
+    ("fab fa-hacker-news-square", "fab fa-hacker-news-square"),  # HackerNews
     ("fab fa-hackerrank", "fab fa-hackerrank"),  # HackerRank
     ("fab fa-instagram", "fab fa-instagram"),  # Instagram
     ("fab fa-keybase", "fab fa-keybase"),  # Keybase
@@ -196,6 +198,7 @@ ICON_HUMAN_NAMES = {
     "gitlab": "Gitlab",
     "goodreads": "Goodreads",
     "google-plus-g": "Google Plus",
+    "hacker-news-square": "Hacker News",
     "hackerrank": "HackerRank",
     "instagram": "Instagram",
     "keybase": "Keybase",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -129,6 +129,8 @@ ICONS = defaultdict(
         "www.quora.com": "fab fa-quora",
         "slideshare.net": "fab fa-slideshare",
         "www.slideshare.net": "fab fa-slideshare",
+        "spotify.com": "fab fa-spotify",
+        "open.spotify.com": "fab fa-spotify",
     },
 )
 
@@ -185,6 +187,7 @@ ICON_CHOICES = (
     ("fab fa-slideshare", "fab fa-slideshare"),  # SlideShare
     ("fab fa-snapchat-ghost", "fab fa-snapchat-ghost"),  # Snapchat
     ("fab fa-soundcloud", "fab fa-soundcloud"),  # Soundcloud
+    ("fab fa-spotify", "fab fa-spotify"),  # Spotify
     ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
     ("fab fa-steam", "fab fa-steam"),  # Steam
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
@@ -250,6 +253,7 @@ ICON_HUMAN_NAMES = {
     "slideshare": "SlideShare",
     "snapchat-ghost": "Snapchat",
     "soundcloud": "Soundcloud",
+    "spotify": "Spotify",
     "stack-overflow": "Stack Overflow",
     "steam": "Steam",
     "teamspeak": "Teamspeak",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -99,6 +99,9 @@ ICONS = defaultdict(
         "500px.com": "fab fa-500px",
         "www.500px.com": "fab fa-500px",
         "bandcamp.com": "fab fa-bandcamp",
+        "blogspot.com": "fab fa-blogger-b",
+        "blogger.com": "fab fa-blogger-b",
+        "www.blogger.com": "fab fa-blogger-b",
     },
 )
 
@@ -110,6 +113,7 @@ ICON_CHOICES = (
     ("fab fa-bandcamp", "fab fa-bandcamp"),  # BandCamp
     ("fab fa-behance", "fab fa-behance"),  # Behance
     ("fab fa-bitbucket", "fab fa-bitbucket"),  # Bitbucket
+    ("fab fa-blogger-b", "fab fa-blogger-b"),  # Blogger
     ("fab fa-codepen", "fab fa-codepen"),  # Codepen
     ("fab fa-deviantart", "fab fa-deviantart"),  # Deviantart
     ("fab fa-diaspora", "fab fa-diaspora"),  # Diaspora
@@ -160,6 +164,7 @@ ICON_HUMAN_NAMES = {
     "bandcamp": "BandCamp",
     "behance": "Behance",
     "bitbucket": "Bitbucket",
+    "blogger-b": "Blogger",
     "codepen": "Codepen",
     "deviantart": "Deviantart",
     "diaspora": "Diaspora",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -87,8 +87,9 @@ ICONS = defaultdict(
         "www.ravelry.com": "fab fa-ravelry",
         "last.fm": "fab fa-lastfm",
         "www.last.fm": "fab fa-lastfm",
-        "telegram.org": "fab fa-telegram",
-        "www.telegram.org": "fab fa-telegram",
+        "telegram.dog": "fab fa-telegram-plane",
+        "telegram.me": "fab fa-telegram-plane",
+        "t.me": "fab fa-telegram-plane",
         "linkedin.com": "fab fa-linkedin",
         "www.linkedin.com": "fab fa-linkedin",
     },
@@ -132,13 +133,13 @@ ICON_CHOICES = (
     ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
     ("fab fa-steam", "fab fa-steam"),  # Steam
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
+    ("fab fa-telegram-plane", "fab fa-telegram-plane"),  # Telegram
     ("fab fa-tumblr", "fab fa-tumblr"),  # Tumblr
     ("fab fa-twitch", "fab fa-twitch"),  # Twitch
     ("fab fa-twitter", "fab fa-twitter"),  # Twitter
     ("fab fa-untappd", "fab fa-untappd"),  # Untappd
     ("fab fa-vimeo", "fab fa-vimeo"),  # Vimeo
     ("fab fa-youtube", "fab fa-youtube"),  # YouTube
-    ("fab fa-telegram", "fab fa-telegram"),  # Telegram
 )
 
 ICON_HUMAN_NAMES = {
@@ -179,13 +180,13 @@ ICON_HUMAN_NAMES = {
     "stack-overflow": "Stack Overflow",
     "steam": "Steam",
     "teamspeak": "Teamspeak",
+    "telegram-plane": "Telegram",
     "tumblr": "Tumblr",
     "twitch": "Twitch",
     "twitter": "Twitter",
     "untappd": "Untappd",
     "vimeo": "Vimeo",
     "youtube": "YouTube",
-    "telegram": "Telegram",
 }
 
 QUALITY_CHOICES = ((0, "low"), (1, "mid"), (2, "high"))

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -92,6 +92,8 @@ ICONS = defaultdict(
         "t.me": "fab fa-telegram-plane",
         "linkedin.com": "fab fa-linkedin",
         "www.linkedin.com": "fab fa-linkedin",
+        "paypal.me": "fab fa-paypal",
+        "www.paypal.me": "fab fa-paypal",
     },
 )
 

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -113,6 +113,8 @@ ICONS = defaultdict(
         "news.ycombinator.com": "fab fa-hacker-news-square",
         "hackerrank.com": "fab fa-hackerrank",
         "www.hackerrank.com": "fab fa-hackerrank",
+        "jsfiddle.net": "fab fa-jsfiddle",
+        "www.jsfiddle.net": "fab fa-jsfiddle",
     },
 )
 
@@ -144,6 +146,7 @@ ICON_CHOICES = (
     ("fab fa-hacker-news-square", "fab fa-hacker-news-square"),  # HackerNews
     ("fab fa-hackerrank", "fab fa-hackerrank"),  # HackerRank
     ("fab fa-instagram", "fab fa-instagram"),  # Instagram
+    ("fab fa-jsfiddle", "fab fa-jsfiddle"),  # JSFiddle
     ("fab fa-keybase", "fab fa-keybase"),  # Keybase
     ("fab fa-kickstarter", "fab fa-kickstarter"),  # Kickstarter
     ("fab fa-lastfm", "fab fa-lastfm"),  # Last
@@ -201,6 +204,7 @@ ICON_HUMAN_NAMES = {
     "hacker-news-square": "Hacker News",
     "hackerrank": "HackerRank",
     "instagram": "Instagram",
+    "jsfiddle": "JSFiddle",
     "keybase": "Keybase",
     "kickstarter": "Kickstarter",
     "lastfm": "Last",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -151,6 +151,8 @@ ICONS = defaultdict(
         "dailymotion.com": "fab fa-dailymotion",
         "www.dailymotion.com": "fab fa-dailymotion",
         "itch.io": "fab fa-itch-io",
+        "unsplash.com": "fab fa-unsplash",
+        "www.unsplash.com": "fab fa-unsplash",
     },
 )
 
@@ -224,6 +226,7 @@ ICON_CHOICES = (
     ("fab fa-tumblr", "fab fa-tumblr"),  # Tumblr
     ("fab fa-twitch", "fab fa-twitch"),  # Twitch
     ("fab fa-twitter", "fab fa-twitter"),  # Twitter
+    ("fab fa-unsplash", "fab fa-unsplash"),  # Unsplash
     ("fab fa-untappd", "fab fa-untappd"),  # Untappd
     ("fab fa-vimeo", "fab fa-vimeo"),  # Vimeo
     ("fab fa-vk", "fab fa-vk"),  # VK
@@ -302,6 +305,7 @@ ICON_HUMAN_NAMES = {
     "tumblr": "Tumblr",
     "twitch": "Twitch",
     "twitter": "Twitter",
+    "unsplash": "Unsplash",
     "untappd": "Untappd",
     "vimeo": "Vimeo",
     "vk": "VK",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -133,6 +133,8 @@ ICONS = defaultdict(
         "open.spotify.com": "fab fa-spotify",
         "stackexchange.com": "fab fa-stack-exchange",
         "www.stackexchange.com": "fab fa-stack-exchange",
+        "strava.com": "fab fa-strava",
+        "www.strava.com": "fab fa-strava",
     },
 )
 
@@ -193,6 +195,7 @@ ICON_CHOICES = (
     ("fab fa-stack-exchange", "fab fa-stack-exchange"),  # Stack Exchange
     ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
     ("fab fa-steam", "fab fa-steam"),  # Steam
+    ("fab fa-strava", "fab fa-strava"),  # Strava
     ("fab fa-teamspeak", "fab fa-teamspeak"),  # Teamspeak
     ("fab fa-telegram-plane", "fab fa-telegram-plane"),  # Telegram
     ("fab fa-tumblr", "fab fa-tumblr"),  # Tumblr
@@ -260,6 +263,7 @@ ICON_HUMAN_NAMES = {
     "stack-exchange": "Stack Exchange",
     "stack-overflow": "Stack Overflow",
     "steam": "Steam",
+    "strava": "Strava",
     "teamspeak": "Teamspeak",
     "telegram-plane": "Telegram",
     "tumblr": "Tumblr",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -146,6 +146,8 @@ ICONS = defaultdict(
         "wordpress.com": "fab fa-wordpress-simple",
         "play.google.com": "fab fa-google-play",
         "drive.google.com": "fab fa-google-drive",
+        "flipboard.com": "fab fa-flipboard",
+        "www.flipboard.com": "fab fa-flipboard",
     },
 )
 
@@ -169,6 +171,7 @@ ICON_CHOICES = (
     ("fab fa-facebook", "fab fa-facebook"),  # Facebook
     ("fab fa-figma", "fab fa-figma"),  # Figma
     ("fab fa-flickr", "fab fa-flickr"),  # Flickr
+    ("fab fa-flipboard", "fab fa-flipboard"),  # Flipboard
     ("fab fa-foursquare", "fab fa-foursquare"),  # Foursquare
     ("fab fa-github", "fab fa-github"),  # GitHub
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
@@ -244,6 +247,7 @@ ICON_HUMAN_NAMES = {
     "facebook": "Facebook",
     "figma": "Figma",
     "flickr": "Flickr",
+    "flipboard": "Flipboard",
     "foursquare": "Foursquare",
     "github": "GitHub",
     "gitlab": "Gitlab",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -98,6 +98,7 @@ ICONS = defaultdict(
         "www.angel.co": "fab fa-angellist",
         "500px.com": "fab fa-500px",
         "www.500px.com": "fab fa-500px",
+        "bandcamp.com": "fab fa-bandcamp",
     },
 )
 
@@ -106,6 +107,7 @@ ICON_CHOICES = (
     ("fas fa-envelope", "fas fa-envelope"),  # email
     ("fab fa-500px", "fab fa-500px"),  # 500px
     ("fab fa-angellist", "fab fa-angellist"),  # AngelList
+    ("fab fa-bandcamp", "fab fa-bandcamp"),  # BandCamp
     ("fab fa-behance", "fab fa-behance"),  # Behance
     ("fab fa-bitbucket", "fab fa-bitbucket"),  # Bitbucket
     ("fab fa-codepen", "fab fa-codepen"),  # Codepen
@@ -155,6 +157,7 @@ ICON_HUMAN_NAMES = {
     "envelope": "email",
     "500px": "500px",
     "angellist": "AngelList",
+    "bandcamp": "BandCamp",
     "behance": "Behance",
     "bitbucket": "Bitbucket",
     "codepen": "Codepen",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -21,7 +21,7 @@ ICONS = defaultdict(
         "www.keybase.io": "fab fa-keybase",
         "mastodon.social": "fab fa-mastodon",
         "pixelfed.social": "fa fa-pixelfed",
-        "element.io": "fa fa-matrix-org",
+        "matrix.to": "fa fa-matrix-org",
         "plus.google.com": "fab fa-google-plus-g",
         "twitch.tv": "fab fa-twitch",
         "www.twitch.tv": "fab fa-twitch",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -143,6 +143,7 @@ ICONS = defaultdict(
         "www.vk.com": "fab fa-vk",
         "wikipedia.org": "fab fa-wikipedia-w",
         "en.wikipedia.org": "fab fa-wikipedia-w",
+        "wordpress.com": "fab fa-wordpress-simple",
     },
 )
 
@@ -215,6 +216,7 @@ ICON_CHOICES = (
     ("fab fa-vimeo", "fab fa-vimeo"),  # Vimeo
     ("fab fa-vk", "fab fa-vk"),  # VK
     ("fab fa-wikipedia-w", "fab fa-wikipedia-w"),  # Wikipedia
+    ("fab fa-wordpress-simple", "fab fa-wordpress-simple"),  # Wordpress
     ("fab fa-youtube", "fab fa-youtube"),  # YouTube
 )
 
@@ -287,6 +289,7 @@ ICON_HUMAN_NAMES = {
     "vimeo": "Vimeo",
     "vk": "VK",
     "wikipedia-w": "Wikipedia",
+    "wordpress-simple": "Wordpress",
     "youtube": "YouTube",
 }
 

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -102,6 +102,8 @@ ICONS = defaultdict(
         "blogspot.com": "fab fa-blogger-b",
         "blogger.com": "fab fa-blogger-b",
         "www.blogger.com": "fab fa-blogger-b",
+        "dev.to": "fab fa-dev",
+        "www.dev.to": "fab fa-dev",
     },
 )
 
@@ -115,6 +117,7 @@ ICON_CHOICES = (
     ("fab fa-bitbucket", "fab fa-bitbucket"),  # Bitbucket
     ("fab fa-blogger-b", "fab fa-blogger-b"),  # Blogger
     ("fab fa-codepen", "fab fa-codepen"),  # Codepen
+    ("fab fa-dev", "fab fa-dev"),  # DEV.to
     ("fab fa-deviantart", "fab fa-deviantart"),  # Deviantart
     ("fab fa-diaspora", "fab fa-diaspora"),  # Diaspora
     ("fab fa-discord", "fab fa-discord"),  # Discord
@@ -166,6 +169,7 @@ ICON_HUMAN_NAMES = {
     "bitbucket": "Bitbucket",
     "blogger-b": "Blogger",
     "codepen": "Codepen",
+    "dev": "DEV.to",
     "deviantart": "Deviantart",
     "diaspora": "Diaspora",
     "discord": "Discord",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -125,6 +125,8 @@ ICONS = defaultdict(
         "www.periscope.tv": "fab fa-periscope",
         "producthunt.com": "fab fa-product-hunt",
         "www.producthunt.com": "fab fa-product-hunt",
+        "quora.com": "fab fa-quora",
+        "www.quora.com": "fab fa-quora",
     },
 )
 
@@ -173,6 +175,7 @@ ICON_CHOICES = (
     ("fab fa-pinterest", "fab fa-pinterest"),  # Pinterest
     ("fa fa-pixelfed", "fa fa-pixelfed"),  # Pixelfed
     ("fab fa-product-hunt", "fab fa-product-hunt"),  # Product Hunt
+    ("fab fa-quora", "fab fa-quora"),  # Quora
     ("fab fa-ravelry", "fab fa-ravelry"),  # Ravelry
     ("fab fa-reddit", "fab fa-reddit"),  # Reddit
     ("fab fa-skype", "fab fa-skype"),  # Skype
@@ -236,6 +239,7 @@ ICON_HUMAN_NAMES = {
     "pinterest": "Pinterest",
     "pixelfed": "Pixelfed",
     "product-hunt": "Product Hunt",
+    "quora": "Quora",
     "ravelry": "Ravelry",
     "reddit": "Reddit",
     "skype": "Skype",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -144,6 +144,7 @@ ICONS = defaultdict(
         "wikipedia.org": "fab fa-wikipedia-w",
         "en.wikipedia.org": "fab fa-wikipedia-w",
         "wordpress.com": "fab fa-wordpress-simple",
+        "play.google.com": "fab fa-google-play",
     },
 )
 
@@ -171,6 +172,7 @@ ICON_CHOICES = (
     ("fab fa-github", "fab fa-github"),  # GitHub
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
     ("fab fa-goodreads", "fab fa-goodreads"),  # Goodreads
+    ("fab fa-google-play", "fab fa-google-play"),  # Google Play
     ("fab fa-google-plus-g", "fab fa-google-plus-g"),  # Google Plus
     ("fab fa-hacker-news-square", "fab fa-hacker-news-square"),  # HackerNews
     ("fab fa-hackerrank", "fab fa-hackerrank"),  # HackerRank
@@ -244,6 +246,7 @@ ICON_HUMAN_NAMES = {
     "github": "GitHub",
     "gitlab": "Gitlab",
     "goodreads": "Goodreads",
+    "google-play": "Google Play",
     "google-plus-g": "Google Plus",
     "hacker-news-square": "Hacker News",
     "hackerrank": "HackerRank",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -115,6 +115,7 @@ ICON_CHOICES = (
     ("fab fa-keybase", "fab fa-keybase"),  # Keybase
     ("fab fa-kickstarter", "fab fa-kickstarter"),  # Kickstarter
     ("fab fa-lastfm", "fab fa-lastfm"),  # Last
+    ("fab fa-linkedin", "fab fa-linkedin"),  # LinkedIn
     ("fab fa-mastodon", "fab fa-mastodon"),  # Mastodon
     ("fa fa-matrix-org", "fa fa-matrix-org"),  # Matrix
     ("fab fa-medium", "fab fa-medium"),  # Medium
@@ -138,7 +139,6 @@ ICON_CHOICES = (
     ("fab fa-vimeo", "fab fa-vimeo"),  # Vimeo
     ("fab fa-youtube", "fab fa-youtube"),  # YouTube
     ("fab fa-telegram", "fab fa-telegram"),  # Telegram
-    ("fab fa-linkedin", "fab fa-linkedin"),  # LinkedIn
 )
 
 ICON_HUMAN_NAMES = {
@@ -162,6 +162,7 @@ ICON_HUMAN_NAMES = {
     "keybase": "Keybase",
     "kickstarter": "Kickstarter",
     "lastfm": "Last",
+    "linkedin": "LinkedIn",
     "mastodon": "Mastodon",
     "matrix-org": "Matrix",
     "medium": "Medium",
@@ -185,7 +186,6 @@ ICON_HUMAN_NAMES = {
     "vimeo": "Vimeo",
     "youtube": "YouTube",
     "telegram": "Telegram",
-    "linkedin": "LinkedIn",
 }
 
 QUALITY_CHOICES = ((0, "low"), (1, "mid"), (2, "high"))

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -150,6 +150,7 @@ ICONS = defaultdict(
         "www.flipboard.com": "fab fa-flipboard",
         "dailymotion.com": "fab fa-dailymotion",
         "www.dailymotion.com": "fab fa-dailymotion",
+        "itch.io": "fab fa-itch-io",
     },
 )
 
@@ -185,6 +186,7 @@ ICON_CHOICES = (
     ("fab fa-hacker-news-square", "fab fa-hacker-news-square"),  # HackerNews
     ("fab fa-hackerrank", "fab fa-hackerrank"),  # HackerRank
     ("fab fa-instagram", "fab fa-instagram"),  # Instagram
+    ("fab fa-itch-io", "fab fa-itch-io"),  # itch.io
     ("fab fa-jsfiddle", "fab fa-jsfiddle"),  # JSFiddle
     ("fab fa-kaggle", "fab fa-kaggle"),  # Kaggle
     ("fab fa-keybase", "fab fa-keybase"),  # Keybase
@@ -262,6 +264,7 @@ ICON_HUMAN_NAMES = {
     "hacker-news-square": "Hacker News",
     "hackerrank": "HackerRank",
     "instagram": "Instagram",
+    "itch-io": "itch.io",
     "jsfiddle": "JSFiddle",
     "kaggle": "Kaggle",
     "keybase": "Keybase",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -108,6 +108,8 @@ ICONS = defaultdict(
         "www.figma.com": "fab fa-figma",
         "flickr.com": "fab fa-flickr",
         "www.flickr.com": "fab fa-flickr",
+        "foursquare.com": "fab fa-foursquare",
+        "www.foursquare.com": "fab fa-foursquare",
     },
 )
 
@@ -131,6 +133,7 @@ ICON_CHOICES = (
     ("fab fa-facebook", "fab fa-facebook"),  # Facebook
     ("fab fa-figma", "fab fa-figma"),  # Figma
     ("fab fa-flickr", "fab fa-flickr"),  # Flickr
+    ("fab fa-foursquare", "fab fa-foursquare"),  # Foursquare
     ("fab fa-github", "fab fa-github"),  # GitHub
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
     ("fab fa-goodreads", "fab fa-goodreads"),  # Goodreads
@@ -185,6 +188,7 @@ ICON_HUMAN_NAMES = {
     "facebook": "Facebook",
     "figma": "Figma",
     "flickr": "Flickr",
+    "foursquare": "Foursquare",
     "github": "GitHub",
     "gitlab": "Gitlab",
     "goodreads": "Goodreads",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -155,6 +155,8 @@ ICONS = defaultdict(
         "www.unsplash.com": "fab fa-unsplash",
         "tiktok.com": "fab fa-tiktok",
         "www.tiktok.com": "fab fa-tiktok",
+        "speakerdeck.com": "fab fa-speakerdeck",
+        "www.speakerdeck.com": "fab fa-speakerdeck",
     },
 )
 
@@ -217,6 +219,7 @@ ICON_CHOICES = (
     ("fab fa-snapchat-ghost", "fab fa-snapchat-ghost"),  # Snapchat
     ("fab fa-soundcloud", "fab fa-soundcloud"),  # Soundcloud
     ("fab fa-spotify", "fab fa-spotify"),  # Spotify
+    ("fab fa-speakerdeck", "fab fa-speakerdeck"),  # Speaker Deck
     ("fab fa-stack-exchange", "fab fa-stack-exchange"),  # Stack Exchange
     ("fab fa-stack-overflow", "fab fa-stack-overflow"),  # Stackoverflow
     ("fab fa-steam", "fab fa-steam"),  # Steam
@@ -297,6 +300,7 @@ ICON_HUMAN_NAMES = {
     "snapchat-ghost": "Snapchat",
     "soundcloud": "Soundcloud",
     "spotify": "Spotify",
+    "speakerdeck": "Speaker Deck",
     "stack-exchange": "Stack Exchange",
     "stack-overflow": "Stack Overflow",
     "steam": "Steam",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -104,6 +104,8 @@ ICONS = defaultdict(
         "www.blogger.com": "fab fa-blogger-b",
         "dev.to": "fab fa-dev",
         "www.dev.to": "fab fa-dev",
+        "figma.com": "fab fa-figma",
+        "www.figma.com": "fab fa-figma",
     },
 )
 
@@ -125,6 +127,7 @@ ICON_CHOICES = (
     ("fab fa-ello", "fab fa-ello"),  # Ello
     ("fab fa-etsy", "fab fa-etsy"),  # Etsy
     ("fab fa-facebook", "fab fa-facebook"),  # Facebook
+    ("fab fa-figma", "fab fa-figma"),  # Figma
     ("fab fa-github", "fab fa-github"),  # GitHub
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
     ("fab fa-goodreads", "fab fa-goodreads"),  # Goodreads
@@ -177,6 +180,7 @@ ICON_HUMAN_NAMES = {
     "ello": "Ello",
     "etsy": "Etsy",
     "facebook": "Facebook",
+    "figma": "Figma",
     "github": "GitHub",
     "gitlab": "Gitlab",
     "goodreads": "Goodreads",

--- a/wheretofindme/models.py
+++ b/wheretofindme/models.py
@@ -110,6 +110,8 @@ ICONS = defaultdict(
         "www.flickr.com": "fab fa-flickr",
         "foursquare.com": "fab fa-foursquare",
         "www.foursquare.com": "fab fa-foursquare",
+        "hackerrank.com": "fab fa-hackerrank",
+        "www.hackerrank.com": "fab fa-hackerrank",
     },
 )
 
@@ -138,6 +140,7 @@ ICON_CHOICES = (
     ("fab fa-gitlab", "fab fa-gitlab"),  # Gitlab
     ("fab fa-goodreads", "fab fa-goodreads"),  # Goodreads
     ("fab fa-google-plus-g", "fab fa-google-plus-g"),  # Google Plus
+    ("fab fa-hackerrank", "fab fa-hackerrank"),  # HackerRank
     ("fab fa-instagram", "fab fa-instagram"),  # Instagram
     ("fab fa-keybase", "fab fa-keybase"),  # Keybase
     ("fab fa-kickstarter", "fab fa-kickstarter"),  # Kickstarter
@@ -193,6 +196,7 @@ ICON_HUMAN_NAMES = {
     "gitlab": "Gitlab",
     "goodreads": "Goodreads",
     "google-plus-g": "Google Plus",
+    "hackerrank": "HackerRank",
     "instagram": "Instagram",
     "keybase": "Keybase",
     "kickstarter": "Kickstarter",


### PR DESCRIPTION
what started as a simple addition of a link parsing and icon fix turned to a whole different exercise.

I have added 34 new services, modified 3 existing icons and added 5 more URL detection domains. I also took the liberty of bumping the version of font-awesome to the [latest version](https://github.com/FortAwesome/Font-Awesome/releases/latest) - 5.15.0 so that I could support 4 services that weren't in the pack that was included.

I simply iterated over each of the [icons in the pack](https://fontawesome.com/v5.6.3/icons?d=gallery&s=brands) and added services that handled user profiles to the list.
The reason I made each of the services a separate commit is so that I could easily revert if one of them were deemed unnecessary. Let me know if any of these services should not be included and I'll revert those changes.

## Changelog

### Modifications

1. fix Stack Overflow icon ( f2f78d7 )
2. change snapchat ( 4f91f5c ) logo to icon without round
3. Bump font-awesome version from v5.6.3 to v5.15.0 ( 5b145b0 )

### Enhancements

1. replace element.io link with matrix.to ( 21dfd09 )
	Quoting the first line of the [project README](https://github.com/matrix-org/matrix.to/blob/main/README.md)
	> Matrix.to is a simple url redirection service for the Matrix.org ecosystem which lets users share links to matrix entities
2. replace telegram.org with t.me, telegram.me and telegram.do ( [reference](https://github.com/DrKLO/Telegram/blob/master/TMessagesProj/src/main/AndroidManifest.xml#L131-L141) ) 
3. add paypal.me link for paypal thus changing the condition from `endsWith` to `includes` ( 3dad384 )
4. add basic URL detection for pixelfed copying from mastodon ( 66515ad )

### Additions
New services and icons supported that are added
1. 500px f822f19
2. AngelList 1312ffa
3. Bandcamp 043a980
4. Blogger 3d8af1e ( modified existing icon to use plain icon without square background )
5. DEV.to 67ecf61
6. Figma d0cf8a7
7. Flickr cf8fe16
8. Foursquare 0e9e7a5
9. HackerRank e6f5b1f
10. HackerNews 20f12eb
11. JSFiddle 7bb1af9
12. Kaggle da2f5f7
13. Leanpub 70f17f7
14. NPM e5b2691
15. Periscope 06d8a26
16. Product Hunt f4f35f6
17. Quora 5875625
18. Slideshare fbe77e9
19. Spotify b514ce5
20. Stack Exchange c06b92e
21. Strava 88f0d97
22. Trello 2727a73
23. Trip Advisor 16336d3
24. VKontakte 4aa389f
25. Wikipedia b7effc8
26. wordpress.com 48ef002
27. Google Play Store 85d5287
28. Google Drive d3296e2
29. Flipboard be4fec2

after bumping font-awesome to v5.15.0

30. DailyMotion 5978193
31. itch.io fbc5cfb
32. Unsplash 757cdd8
33. TikTok 803f675
34. Speaker Deck 79abdcc